### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,24 +107,18 @@ $ yarn start
 
 ## Change next.config.js to:
 ```
-const { withExpo } = require('@expo/next-adapter');
-const withFonts = require('next-fonts');
+const { withExpo } = require('@expo/next-adapter')
+const withFonts = require('next-fonts')
 const withImages = require('next-images')
-const withTM = require('next-transpile-modules')
 const withPlugins = require('next-compose-plugins')
 
+const withTM = require('next-transpile-modules')([
+  'expo-next-react-navigation',
+  // you can add other modules that need traspiling here
+])
+
 module.exports = withPlugins(
-  [
-    [
-      withTM,
-      {
-        transpileModules: ['expo-next-react-navigation'],
-      },
-    ],
-    withFonts,
-    withImages,
-    [withExpo, { projectRoot: __dirname }],
-  ],
+  [withTM, withFonts, withImages, [withExpo, { projectRoot: __dirname }]],
   {
     // ...
   }


### PR DESCRIPTION
Change `next.config.js` to match the updated docs for `expo-next-react-navigation` (https://github.com/nandorojo/expo-next-react-navigation/commit/e915879bf61b820666351c3cc370664ba5e827f3)